### PR TITLE
Add Wi-Fi signal strength indicator to BOX-3 UI

### DIFF
--- a/main/board/ui_status.c
+++ b/main/board/ui_status.c
@@ -18,6 +18,7 @@
 #include "bsp/esp-box-3.h"
 
 #include "board/ui_status.h"
+#include "system/wifi_support.h"
 
 static const char *TAG = "hue-voice";
 
@@ -299,6 +300,34 @@ static int text_width(const char *text, int scale) {
 }
 
 /**
+ * @brief Draw a single left-aligned line of text on the status screen.
+ * @param x Left pixel position for the rendered text.
+ * @param y Top pixel position for the text baseline block.
+ * @param scale Pixel scale factor for the built-in font.
+ * @param color RGB565 text color.
+ * @param text The text to render.
+ * @return This function does not return a value.
+ */
+static void draw_text(int x, int y, int scale, uint16_t color, const char *text) {
+    char upper[64];
+    uppercase_copy(upper, sizeof(upper), text);
+
+    const int char_width = 5 * scale;
+
+    for (size_t i = 0; upper[i] != '\0'; ++i) {
+        const glyph_t *glyph = find_glyph(upper[i]);
+        for (int row = 0; row < 7; ++row) {
+            for (int col = 0; col < 5; ++col) {
+                if (glyph->rows[row] & (1U << (4 - col))) {
+                    fill_rect(x + (col * scale), y + (row * scale), scale, scale, color);
+                }
+            }
+        }
+        x += char_width + UI_CHAR_SPACING;
+    }
+}
+
+/**
  * @brief Calculate the maximum number of monospaced characters that fit on one UI text line.
  * @param scale Pixel scale factor for the built-in font.
  * @return The maximum character count that fits within the screen width.
@@ -323,18 +352,29 @@ static void draw_text_centered(int y, int scale, uint16_t color, const char *tex
 
     int width = text_width(upper, scale);
     int x = (UI_SCREEN_WIDTH - width) / 2;
-    const int char_width = 5 * scale;
+    draw_text(x, y, scale, color, upper);
+}
 
-    for (size_t i = 0; upper[i] != '\0'; ++i) {
-        const glyph_t *glyph = find_glyph(upper[i]);
-        for (int row = 0; row < 7; ++row) {
-            for (int col = 0; col < 5; ++col) {
-                if (glyph->rows[row] & (1U << (4 - col))) {
-                    fill_rect(x + (col * scale), y + (row * scale), scale, scale, color);
-                }
-            }
-        }
-        x += char_width + UI_CHAR_SPACING;
+/**
+ * @brief Draw a compact Wi-Fi signal-strength icon in the top-right corner.
+ * @return This function does not return a value.
+ */
+static void draw_wifi_indicator(void) {
+    const uint8_t level = wifi_signal_level();
+    const bool connected = wifi_is_connected();
+    const uint16_t active = connected ? rgb565(255, 255, 255) : rgb565(248, 113, 113);
+    const uint16_t inactive = connected ? rgb565(148, 163, 184) : rgb565(127, 29, 29);
+    const int base_x = UI_SCREEN_WIDTH - 36;
+    const int base_y = 22;
+    const int bar_width = 4;
+    const int bar_gap = 3;
+    const int bar_heights[4] = {4, 8, 12, 16};
+
+    for (int i = 0; i < 4; ++i) {
+        const int x = base_x + (i * (bar_width + bar_gap));
+        const int h = bar_heights[i];
+        const int y = base_y - h;
+        fill_rect(x, y, bar_width, h, i < level ? active : inactive);
     }
 }
 
@@ -411,6 +451,7 @@ static void render_status(ui_status_state_t state, const char *detail) {
     const char *subtitle = state_subtitle(state);
 
     fill_rect(0, 0, UI_SCREEN_WIDTH, UI_SCREEN_HEIGHT, bg);
+    draw_wifi_indicator();
     if (title != NULL && title[0] != '\0') {
         draw_text_centered(28, UI_TITLE_SCALE, fg, title);
     }
@@ -436,6 +477,7 @@ static void render_clock(const char *time_text, const char *date_text, const cha
     const uint16_t muted = rgb565(191, 219, 254);
 
     fill_rect(0, 0, UI_SCREEN_WIDTH, UI_SCREEN_HEIGHT, bg);
+    draw_wifi_indicator();
     draw_text_centered(24, UI_BODY_SCALE, muted, "LOCAL TIME");
     draw_text_centered(72, UI_TITLE_SCALE, fg, time_text != NULL ? time_text : "");
     draw_text_centered(136, UI_BODY_SCALE, fg, date_text != NULL ? date_text : "");

--- a/main/board/ui_status.c
+++ b/main/board/ui_status.c
@@ -271,6 +271,37 @@ static void fill_rect(int x, int y, int w, int h, uint16_t color) {
 }
 
 /**
+ * @brief Draw a clipped rectangle outline in the framebuffer.
+ * @param x Left edge in pixels.
+ * @param y Top edge in pixels.
+ * @param w Rectangle width in pixels.
+ * @param h Rectangle height in pixels.
+ * @param thickness Outline thickness in pixels.
+ * @param color RGB565 outline color.
+ * @return This function does not return a value.
+ */
+static void draw_rect_outline(int x, int y, int w, int h, int thickness, uint16_t color) {
+    if (w <= 0 || h <= 0 || thickness <= 0) {
+        return;
+    }
+
+    if (thickness * 2 > w) {
+        thickness = w / 2;
+    }
+    if (thickness * 2 > h) {
+        thickness = h / 2;
+    }
+    if (thickness <= 0) {
+        thickness = 1;
+    }
+
+    fill_rect(x, y, w, thickness, color);
+    fill_rect(x, y + h - thickness, w, thickness, color);
+    fill_rect(x, y, thickness, h, color);
+    fill_rect(x + w - thickness, y, thickness, h, color);
+}
+
+/**
  * @brief Copy text into a buffer while converting it to uppercase.
  * @param dst Destination buffer for the uppercase result.
  * @param dst_size Size of the destination buffer in bytes.
@@ -361,9 +392,7 @@ static void draw_text_centered(int y, int scale, uint16_t color, const char *tex
  */
 static void draw_wifi_indicator(void) {
     const uint8_t level = wifi_signal_level();
-    const bool connected = wifi_is_connected();
-    const uint16_t active = connected ? rgb565(255, 255, 255) : rgb565(248, 113, 113);
-    const uint16_t inactive = connected ? rgb565(148, 163, 184) : rgb565(127, 29, 29);
+    const uint16_t active = rgb565(255, 255, 255);
     const int base_x = UI_SCREEN_WIDTH - 36;
     const int base_y = 22;
     const int bar_width = 4;
@@ -374,7 +403,11 @@ static void draw_wifi_indicator(void) {
         const int x = base_x + (i * (bar_width + bar_gap));
         const int h = bar_heights[i];
         const int y = base_y - h;
-        fill_rect(x, y, bar_width, h, i < level ? active : inactive);
+        if (i < level) {
+            fill_rect(x, y, bar_width, h, active);
+        } else {
+            draw_rect_outline(x, y, bar_width, h, 1, active);
+        }
     }
 }
 

--- a/main/system/wifi_support.c
+++ b/main/system/wifi_support.c
@@ -113,3 +113,45 @@ esp_err_t wifi_init_sta(void) {
 bool wifi_is_connected(void) {
     return s_wifi_connected;
 }
+
+/**
+ * @brief Read the RSSI of the currently connected Wi-Fi access point.
+ * @return Current RSSI in dBm, or 0 when disconnected or unavailable.
+ */
+int8_t wifi_signal_rssi_dbm(void) {
+    if (!s_wifi_connected) {
+        return 0;
+    }
+
+    wifi_ap_record_t ap_info = {0};
+    esp_err_t err = esp_wifi_sta_get_ap_info(&ap_info);
+    if (err != ESP_OK) {
+        return 0;
+    }
+
+    return ap_info.rssi;
+}
+
+/**
+ * @brief Map the current Wi-Fi RSSI to a simple 0-4 signal-strength level.
+ * @return Signal level from 0 (disconnected/very weak) to 4 (strong).
+ */
+uint8_t wifi_signal_level(void) {
+    int8_t rssi = wifi_signal_rssi_dbm();
+    if (!s_wifi_connected || rssi == 0) {
+        return 0;
+    }
+    if (rssi >= -55) {
+        return 4;
+    }
+    if (rssi >= -67) {
+        return 3;
+    }
+    if (rssi >= -75) {
+        return 2;
+    }
+    if (rssi >= -85) {
+        return 1;
+    }
+    return 0;
+}

--- a/main/system/wifi_support.h
+++ b/main/system/wifi_support.h
@@ -6,3 +6,5 @@
 
 esp_err_t wifi_init_sta(void);
 bool wifi_is_connected(void);
+int8_t wifi_signal_rssi_dbm(void);
+uint8_t wifi_signal_level(void);


### PR DESCRIPTION
## Summary
This change replaces the binary Wi-Fi connected/disconnected badge with a compact signal-strength indicator in the BOX-3 UI.

During investigation of issue #5, Piper itself was validated as healthy after updating the server container and timing the Wyoming stream locally and over the LAN. The remaining playback symptom only reproduced when the device was effectively on the wrong mesh node / poor Wi-Fi path. That made the real operational gap clear: the device UI did not expose enough network-state detail to quickly distinguish a TTS backend problem from a Wi-Fi quality problem.

This PR adds a 0-4 bar Wi-Fi indicator driven by live AP RSSI so that weak or marginal connections are visible directly on the device.

Closes #5.

## What Changed
- Added `wifi_signal_rssi_dbm()` in `wifi_support.c` to read the current AP RSSI with `esp_wifi_sta_get_ap_info()`.
- Added `wifi_signal_level()` in `wifi_support.c` to map RSSI into a simple 0-4 strength level.
- Replaced the top-right `WIFI/OFF` badge in `ui_status.c` with a 4-bar signal indicator.
- Kept the indicator visible on both the standard status screens and the clock screen.

## Signal Mapping
- 4 bars: `>= -55 dBm`
- 3 bars: `>= -67 dBm`
- 2 bars: `>= -75 dBm`
- 1 bar: `>= -85 dBm`
- 0 bars: disconnected or weaker than `-85 dBm`

## Why This Solves The Issue
The original report looked like a Piper streaming problem after server reboot. The investigation showed:
- the old Piper host had been on an older container build
- after upgrading Piper, the server streamed clean Wyoming audio locally
- the same server also streamed cleanly over the LAN from another client
- the bad audio symptom persisted only when the BOX-3 was on a poor mesh/router path

So the durable fix here is improving device observability: the user can now see weak Wi-Fi conditions directly on-screen instead of misattributing jittery playback to the TTS service.

## Verification
- Ran `make format`
- Ran `idf.py build`
- Verified successful firmware build output
- Confirmed the branch already contains the committed UI change
