### PR TITLE
Adjust screen text below status icons

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,6 +5,7 @@ idf_component_register(
         "assistant/followup_audio.c"
         "assistant/presence.c"
         "assistant/session.c"
+        "assistant/timer_status.c"
         "assistant/watchdog.c"
         "commands/assistant_command_dispatch.c"
         "commands/assistant_command_text.c"

--- a/main/assistant/presence.c
+++ b/main/assistant/presence.c
@@ -1,7 +1,6 @@
 #include "assistant/presence.h"
 
 #include <stdint.h>
-#include <stdio.h>
 
 #include "driver/gpio.h"
 #include "freertos/task.h"
@@ -10,6 +9,7 @@
 #include "esp_log.h"
 
 #include "assistant/session.h"
+#include "assistant/timer_status.h"
 #include "assistant_state.h"
 #include "board/board_audio.h"
 #include "board/ui_status.h"
@@ -28,7 +28,6 @@ static const char *TAG = "assistant-presence";
 
 static void presence_clock_task(void *arg);
 static uint32_t monotonic_ms_now(void);
-static void show_timer_status(assistant_runtime_t *rt);
 
 /**
  * @brief Determine whether the most recent presence motion sample is still considered active.
@@ -47,27 +46,6 @@ bool assistant_presence_motion_recent(TickType_t last_motion_tick, TickType_t no
  */
 static uint32_t monotonic_ms_now(void) {
     return (uint32_t) pdTICKS_TO_MS(xTaskGetTickCount());
-}
-
-/**
- * @brief Render the active timer countdown or alarm state on screen.
- * @param rt Shared assistant runtime state whose timer should be shown.
- * @return This function does not return a value.
- */
-static void show_timer_status(assistant_runtime_t *rt) {
-    if (rt == NULL || !rt->timer.active) {
-        return;
-    }
-
-    char detail[24];
-    if (rt->timer.alarming) {
-        snprintf(detail, sizeof(detail), "00:00");
-        ui_status_set(UI_STATUS_TIMER_ALARM, detail);
-        return;
-    }
-
-    timer_runtime_format_remaining(&rt->timer, monotonic_ms_now(), detail, sizeof(detail));
-    ui_status_set(UI_STATUS_TIMER, detail);
 }
 
 /**
@@ -162,7 +140,7 @@ static void presence_clock_task(void *arg) {
             uint32_t remaining_seconds = timer_runtime_remaining_seconds(&rt->timer, monotonic_ms_now());
             if (!display_owned_by_presence || last_timer_alarming ||
                 remaining_seconds != last_timer_remaining_seconds) {
-                show_timer_status(rt);
+                assistant_timer_status_show(rt);
                 display_owned_by_presence = true;
             }
             last_timer_alarming = false;

--- a/main/assistant/session.c
+++ b/main/assistant/session.c
@@ -20,6 +20,7 @@
 
 #include "assistant/command_registry.h"
 #include "assistant/presence.h"
+#include "assistant/timer_status.h"
 #include "assistant/watchdog.h"
 #include "assistant_diagnostics.h"
 #include "assistant_state.h"
@@ -27,7 +28,6 @@
 #include "commands/assistant_commands.h"
 #include "hue/hue_command_runtime.h"
 #include "system/time_support.h"
-#include "timer/timer_runtime.h"
 
 #define COMMAND_WINDOW_MS                  10000
 #define COMMAND_MIN_LISTEN_MS              3000
@@ -43,8 +43,6 @@ static const TickType_t STATUS_HOLD_TIME = pdMS_TO_TICKS(1200);
 static const TickType_t ERROR_STATUS_HOLD_TIME = pdMS_TO_TICKS(ERROR_STATUS_HOLD_MS);
 
 static void audio_feed_set_paused(assistant_runtime_t *rt, bool paused);
-static uint32_t monotonic_ms_now(void);
-static void show_timer_status(assistant_runtime_t *rt);
 static void audio_feed_task(void *arg);
 static void speech_detect_task(void *arg);
 static void execute_command(assistant_runtime_t *rt, int command_id, const char *command_text);
@@ -65,35 +63,6 @@ const char *assistant_session_stage_name(assistant_stage_t stage) {
     default:
         return "unknown";
     }
-}
-
-/**
- * @brief Read the current monotonic uptime in milliseconds.
- * @return Milliseconds since boot truncated to 32 bits.
- */
-static uint32_t monotonic_ms_now(void) {
-    return (uint32_t) pdTICKS_TO_MS(xTaskGetTickCount());
-}
-
-/**
- * @brief Render the active timer countdown or alarm state on screen.
- * @param rt Shared assistant runtime state whose timer should be shown.
- * @return This function does not return a value.
- */
-static void show_timer_status(assistant_runtime_t *rt) {
-    if (rt == NULL || !rt->timer.active) {
-        return;
-    }
-
-    char detail[24];
-    if (rt->timer.alarming) {
-        snprintf(detail, sizeof(detail), "00:00");
-        ui_status_set(UI_STATUS_TIMER_ALARM, detail);
-        return;
-    }
-
-    timer_runtime_format_remaining(&rt->timer, monotonic_ms_now(), detail, sizeof(detail));
-    ui_status_set(UI_STATUS_TIMER, detail);
 }
 
 /**
@@ -131,7 +100,7 @@ static void audio_feed_set_paused(assistant_runtime_t *rt, bool paused) {
  */
 void assistant_session_restore_idle_ui(assistant_runtime_t *rt) {
     if (rt->timer.active) {
-        show_timer_status(rt);
+        assistant_timer_status_show(rt);
         return;
     }
 

--- a/main/assistant/timer_status.c
+++ b/main/assistant/timer_status.c
@@ -1,0 +1,33 @@
+#include "assistant/timer_status.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "freertos/task.h"
+
+#include "board/ui_status.h"
+#include "timer/timer_runtime.h"
+
+/**
+ * @brief Read the current monotonic uptime in milliseconds.
+ * @return Milliseconds since boot truncated to 32 bits.
+ */
+static uint32_t monotonic_ms_now(void) {
+    return (uint32_t) pdTICKS_TO_MS(xTaskGetTickCount());
+}
+
+void assistant_timer_status_show(assistant_runtime_t *rt) {
+    if (rt == NULL || !rt->timer.active) {
+        return;
+    }
+
+    char detail[24];
+    if (rt->timer.alarming) {
+        snprintf(detail, sizeof(detail), "00:00");
+        ui_status_set(UI_STATUS_TIMER_ALARM, detail);
+        return;
+    }
+
+    timer_runtime_format_remaining(&rt->timer, monotonic_ms_now(), detail, sizeof(detail));
+    ui_status_set(UI_STATUS_TIMER, detail);
+}

--- a/main/assistant/timer_status.h
+++ b/main/assistant/timer_status.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "assistant_runtime.h"
+
+/**
+ * @brief Render the active timer countdown or alarm state on screen.
+ * @param rt Shared assistant runtime state whose timer should be shown.
+ * @return This function does not return a value.
+ */
+void assistant_timer_status_show(assistant_runtime_t *rt);

--- a/main/board/ui_status_render.c
+++ b/main/board/ui_status_render.c
@@ -11,11 +11,22 @@
 #include "board/ui_status_font.h"
 #include "system/wifi_support.h"
 
-#define UI_SCREEN_WIDTH  BSP_LCD_H_RES
-#define UI_SCREEN_HEIGHT BSP_LCD_V_RES
-#define UI_TITLE_SCALE   4
-#define UI_BODY_SCALE    2
-#define UI_CHAR_SPACING  2
+#define UI_SCREEN_WIDTH      BSP_LCD_H_RES
+#define UI_SCREEN_HEIGHT     BSP_LCD_V_RES
+#define UI_TITLE_SCALE       4
+#define UI_BODY_SCALE        2
+#define UI_CHAR_SPACING      2
+#define UI_ICON_ROW_BOTTOM_Y 24
+#define UI_ICON_ROW_MARGIN_Y 16
+#define UI_CONTENT_TOP_Y     (UI_ICON_ROW_BOTTOM_Y + UI_ICON_ROW_MARGIN_Y)
+#define UI_STATUS_TITLE_Y    (UI_CONTENT_TOP_Y + 4)
+#define UI_STATUS_SUBTITLE_Y (UI_STATUS_TITLE_Y + 82)
+#define UI_STATUS_DETAIL_Y   (UI_STATUS_SUBTITLE_Y + 50)
+#define UI_DETAIL_ONLY_Y     (UI_CONTENT_TOP_Y + 48)
+#define UI_CLOCK_LABEL_Y     UI_CONTENT_TOP_Y
+#define UI_CLOCK_TIME_Y      (UI_CLOCK_LABEL_Y + 48)
+#define UI_CLOCK_DATE_Y      (UI_CLOCK_TIME_Y + 64)
+#define UI_CLOCK_LOCATION_Y  (UI_CLOCK_DATE_Y + 46)
 
 static uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b);
 static uint16_t state_bg(ui_status_state_t state);
@@ -435,13 +446,15 @@ void ui_status_render_status(uint16_t *frame_buffer,
     draw_volume_indicator(frame_buffer, volume_percent);
     draw_wifi_indicator(frame_buffer);
     if (title != NULL && title[0] != '\0') {
-        draw_text_centered(frame_buffer, 28, UI_TITLE_SCALE, fg, title);
+        draw_text_centered(frame_buffer, UI_STATUS_TITLE_Y, UI_TITLE_SCALE, fg, title);
     }
     if (subtitle != NULL && subtitle[0] != '\0') {
-        draw_text_centered(frame_buffer, 110, UI_BODY_SCALE, fg, subtitle);
+        draw_text_centered(frame_buffer, UI_STATUS_SUBTITLE_Y, UI_BODY_SCALE, fg, subtitle);
     }
     if (detail != NULL && detail[0] != '\0') {
-        const int detail_y = (title != NULL && title[0] == '\0' && subtitle != NULL && subtitle[0] == '\0') ? 72 : 160;
+        const int detail_y = (title != NULL && title[0] == '\0' && subtitle != NULL && subtitle[0] == '\0')
+                               ? UI_DETAIL_ONLY_Y
+                               : UI_STATUS_DETAIL_Y;
         draw_text_block_centered(frame_buffer, detail_y, UI_BODY_SCALE, fg, detail);
     }
 }
@@ -467,10 +480,10 @@ void ui_status_render_clock(uint16_t *frame_buffer,
     fill_rect(frame_buffer, 0, 0, UI_SCREEN_WIDTH, UI_SCREEN_HEIGHT, bg);
     draw_volume_indicator(frame_buffer, volume_percent);
     draw_wifi_indicator(frame_buffer);
-    draw_text_centered(frame_buffer, 24, UI_BODY_SCALE, muted, "LOCAL TIME");
-    draw_text_centered(frame_buffer, 72, UI_TITLE_SCALE, fg, time_text != NULL ? time_text : "");
-    draw_text_centered(frame_buffer, 136, UI_BODY_SCALE, fg, date_text != NULL ? date_text : "");
+    draw_text_centered(frame_buffer, UI_CLOCK_LABEL_Y, UI_BODY_SCALE, muted, "LOCAL TIME");
+    draw_text_centered(frame_buffer, UI_CLOCK_TIME_Y, UI_TITLE_SCALE, fg, time_text != NULL ? time_text : "");
+    draw_text_centered(frame_buffer, UI_CLOCK_DATE_Y, UI_BODY_SCALE, fg, date_text != NULL ? date_text : "");
     if (location_text != NULL && location_text[0] != '\0') {
-        draw_text_block_centered(frame_buffer, 182, UI_BODY_SCALE, muted, location_text);
+        draw_text_block_centered(frame_buffer, UI_CLOCK_LOCATION_Y, UI_BODY_SCALE, muted, location_text);
     }
 }

--- a/tests/bsp/esp-box-3.h
+++ b/tests/bsp/esp-box-3.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define BSP_LCD_H_RES 320
+#define BSP_LCD_V_RES 240

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -28,6 +28,7 @@ cc -std=c11 -Wall -Wextra -Werror \
     "${ROOT_DIR}/tests/test_timer_runtime.c" \
     "${ROOT_DIR}/tests/test_time_format.c" \
     "${ROOT_DIR}/tests/test_time_open_meteo_parse.c" \
+    "${ROOT_DIR}/tests/test_ui_status_render.c" \
     "${ROOT_DIR}/tests/test_volume_control.c" \
     "${ROOT_DIR}/tests/test_weather_format.c" \
     "${ROOT_DIR}/main/assistant/command_registry.c" \
@@ -42,6 +43,8 @@ cc -std=c11 -Wall -Wextra -Werror \
     "${ROOT_DIR}/main/timer/timer_runtime.c" \
     "${ROOT_DIR}/main/time/time_format.c" \
     "${ROOT_DIR}/main/time/time_open_meteo_parse.c" \
+    "${ROOT_DIR}/main/board/ui_status_font.c" \
+    "${ROOT_DIR}/main/board/ui_status_render.c" \
     "${ROOT_DIR}/main/volume/volume_command_map.c" \
     "${ROOT_DIR}/main/volume/volume_control.c" \
     "${ROOT_DIR}/main/weather/weather_format.c" \

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -30,6 +30,8 @@ extern const test_case_t g_time_format_tests[];
 extern const int g_time_format_test_count;
 extern const test_case_t g_time_open_meteo_parse_tests[];
 extern const int g_time_open_meteo_parse_test_count;
+extern const test_case_t g_ui_status_render_tests[];
+extern const int g_ui_status_render_test_count;
 
 static int s_failures;
 static int s_tests_run;
@@ -63,6 +65,7 @@ int main(void) {
     run_test_cases(g_timer_runtime_tests, g_timer_runtime_test_count);
     run_test_cases(g_time_format_tests, g_time_format_test_count);
     run_test_cases(g_time_open_meteo_parse_tests, g_time_open_meteo_parse_test_count);
+    run_test_cases(g_ui_status_render_tests, g_ui_status_render_test_count);
     run_test_cases(g_weather_format_tests, g_weather_format_test_count);
     run_test_cases(g_volume_control_tests, g_volume_control_test_count);
 

--- a/tests/test_ui_status_render.c
+++ b/tests/test_ui_status_render.c
@@ -1,0 +1,72 @@
+#include <stdint.h>
+
+#include "board/ui_status_render.h"
+#include "test_support.h"
+
+#define TEST_SCREEN_WIDTH       320
+#define TEST_SCREEN_HEIGHT      240
+#define TEST_FRAMEBUFFER_PIXELS (TEST_SCREEN_WIDTH * TEST_SCREEN_HEIGHT)
+#define TEST_CLEAR_START_Y      25
+#define TEST_CLEAR_END_Y        39
+
+static uint16_t s_frame_buffer[TEST_FRAMEBUFFER_PIXELS];
+
+/**
+ * @brief Provide a deterministic Wi-Fi indicator level for renderer tests.
+ * @return Wi-Fi signal level shown by the test renderer.
+ */
+uint8_t wifi_signal_level(void) {
+    return 4;
+}
+
+/**
+ * @brief Check that framebuffer rows are filled with a single color.
+ * @param start_y First row to inspect.
+ * @param end_y Last row to inspect.
+ * @return True when every pixel in the row range has the same color.
+ */
+static bool rows_are_solid_color(int start_y, int end_y) {
+    const uint16_t color = s_frame_buffer[(size_t) start_y * TEST_SCREEN_WIDTH];
+
+    for (int y = start_y; y <= end_y; ++y) {
+        for (int x = 0; x < TEST_SCREEN_WIDTH; ++x) {
+            if (s_frame_buffer[((size_t) y * TEST_SCREEN_WIDTH) + x] != color) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @brief Verify status text leaves clear margin below the icon row.
+ * @return True when the status screen keeps the reserved rows clear.
+ */
+static bool status_text_starts_below_icon_margin(void) {
+    ui_status_render_status(s_frame_buffer, UI_STATUS_LISTENING, NULL, 50);
+
+    ASSERT_TRUE(rows_are_solid_color(TEST_CLEAR_START_Y, TEST_CLEAR_END_Y));
+
+    return true;
+}
+
+/**
+ * @brief Verify clock text leaves clear margin below the icon row.
+ * @return True when the clock screen keeps the reserved rows clear.
+ */
+static bool clock_text_starts_below_icon_margin(void) {
+    ui_status_render_clock(s_frame_buffer, "12:34", "Sat Jul 11", "Test City", 50);
+
+    ASSERT_TRUE(rows_are_solid_color(TEST_CLEAR_START_Y, TEST_CLEAR_END_Y));
+
+    return true;
+}
+
+const test_case_t g_ui_status_render_tests[] = {
+    {"status text starts below icon margin", status_text_starts_below_icon_margin},
+    {"clock text starts below icon margin", clock_text_starts_below_icon_margin},
+};
+
+const int g_ui_status_render_test_count =
+    (int) (sizeof(g_ui_status_render_tests) / sizeof(g_ui_status_render_tests[0]));


### PR DESCRIPTION
## Summary
- Lower status and clock text so the top volume and Wi-Fi indicators have their own row with margin below
- Add host renderer regression tests for the reserved icon-row margin
- Extract duplicate timer status rendering into a shared helper used by session and presence flows

Fixes #15

## Verification
- make format
- make test
- make build